### PR TITLE
实用性更新

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,19 @@
 ## Encipher - the PHP code encode tool ##
 
-php code encode &amp; decode
+php代码批量混淆与恢复
 
-A simple demo (see ./index.php)
+**相比主干，做了以下优化**
 
-Good luck!
+1.只对php文件混淆，其他类型的文件原样复制
+
+2.执行时可指定源码绝对路径和指定目标目录的名称
+
+
+**执行方法**
+
+`cd $DIR; //切换到该项目要目录`
+
+`php encode.php -o '源码绝根目录绝对路径' -e 'encoded目录下的相对路径';`
 
 
 
@@ -16,7 +25,7 @@ Good luck!
 
 3.加密使用方法详见：./index.php
 
-> 其中：./encoded目录下存放的就是加密后的实例。
+> 其中：./encoded/*目录下存放的就是加密后的实例。
 
 
 

--- a/encode.php
+++ b/encode.php
@@ -1,0 +1,29 @@
+<?php
+/**
+ * Created by IntelliJ IDEA.
+ * User: huajun102
+ * Date: 2019/6/26
+ * Time: 15:47
+ */
+$app = str_replace('\\', '/', dirname(__FILE__));
+require_once($app . '/lib/encipher.php');
+
+$param_arr = getopt('o:e:');
+//print_r($param_arr);
+$original = $app . '/original'; //待加密的文件目录
+$encoded  = $app . '/encoded/'.$param_arr['e'];  //加密后的文件目录
+if(!file_exists($encoded)){
+    mkdir($encoded,755);
+}
+$encipher = new Encipher($param_arr['o'], $encoded);
+
+/**
+ * 设置加密模式 false = 低级模式; true = 高级模式
+ * 低级模式不使用eval函数
+ * 高级模式使用了eval函数
+ */
+$encipher->advancedEncryption = true;
+
+echo "<pre>\n";
+$encipher->encode();
+echo "</pre>\n";

--- a/lib/encipher.php
+++ b/lib/encipher.php
@@ -5,8 +5,8 @@ Author: Jacky Yu <jacky325@qq.com>
 Copyright (c): 2012-2017 Jacky Yu, All rights reserved
 Version: 1.1.2
 
-* This library is free software; you can redistribute it and/or modify it.
-* You may contact the author of Encipher by e-mail at: jacky325@qq.com
+ * This library is free software; you can redistribute it and/or modify it.
+ * You may contact the author of Encipher by e-mail at: jacky325@qq.com
 
 The latest version of Encipher can be obtained from:
 https://github.com/uniqid/encipher
@@ -274,8 +274,14 @@ EOT;
      * get php encoded code
      */
     private function _getPHPEncode($file, $enkey, $dekey){
-        $code   = $this->_getPHPCode($file);
-        $enCode = strtr(base64_encode($code), $enkey, $dekey);
+        //如果是php文件，才进行混淆
+        if(strstr($file,'.php')){
+            $code   = $this->_getPHPCode($file);
+            $enCode = strtr(base64_encode($code), $enkey, $dekey);
+        }else{
+            return '';
+        }
+
         return $enCode;
     }
 
@@ -333,7 +339,13 @@ EOT;
    
     private function _saveEncryptFile($file, $enCode, $enkey = null, $dekey = null){
         $to = $this->encoded_file . '/' . $file;
-        file_put_contents($to, $enCode);
+        //如果是php文件，存储混淆后的代码到目标路径，否则按原样复制
+        if(strstr($file,'.php')){
+            file_put_contents($to, $enCode);
+        }else{
+            file_put_contents($to,file_get_contents($this->source_file . '/' . $file));
+        }
+
         echo $to . "\n";
     }
 }


### PR DESCRIPTION
1.只对php文件混淆，其他类型的文件原样复制
2.执行时可指定源码绝对路径和指定目标目录的名称